### PR TITLE
Fixed Missing Resource when assigning groups to unverified users

### DIFF
--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -71,12 +71,14 @@ func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		return nil, "", nil, err
 	}
 
-	if len(domains) == 0 || len(domains) > 1 {
-		domainID = ""
+	if len(domains) == 1 {
+		for _, domain := range domains {
+			domainID = domain.ID
+		}
 	}
 
-	for _, domain := range domains {
-		domainID = domain.ID
+	if len(domains) == 0 || len(domains) > 1 { // no domains or multiple domains
+		domainID = ""
 	}
 
 	users, nextCursor, err = u.client.ListUsers(ctx, domainID, bag.PageToken())

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -52,6 +52,7 @@ func userResource(ctx context.Context, pId *v2.ResourceId, user *newrelic.User) 
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
 func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+	var domainId string
 	if parentResourceID == nil {
 		return nil, "", nil, nil
 	}
@@ -62,7 +63,16 @@ func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		return nil, "", nil, err
 	}
 
-	users, nextCursor, err := u.client.ListUsers(ctx, bag.PageToken())
+	domains, _, err := u.client.ListDomains(ctx, bag.PageToken())
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	for _, domain := range domains {
+		domainId = domain.ID
+	}
+
+	users, nextCursor, err := u.client.ListUsers(ctx, domainId, bag.PageToken())
 	if err != nil {
 		return nil, "", nil, err
 	}

--- a/pkg/newrelic/client.go
+++ b/pkg/newrelic/client.go
@@ -132,7 +132,7 @@ func (c *Client) ListUsers(ctx context.Context, domainId string, cursor string) 
 		nextCursor = domain.Users.NextCursor
 	}
 
-	return users, nextCursor, err
+	return users, nextCursor, nil
 }
 
 // GetOrg returns organization details.

--- a/pkg/newrelic/client.go
+++ b/pkg/newrelic/client.go
@@ -510,7 +510,6 @@ func (c *Client) doRequest(ctx context.Context, q string, v map[string]interface
 		Query:     q,
 		Variables: v,
 	}
-	// fmt.Println(body)
 	reqBody, err := json.Marshal(body)
 	if err != nil {
 		return err

--- a/pkg/newrelic/graphql.go
+++ b/pkg/newrelic/graphql.go
@@ -7,16 +7,34 @@ const (
 	actorBaseQ = "actor { %s }"
 
 	usersQuery = `users {
-		userSearch(cursor: $userCursor) { 
-			nextCursor 
-			totalCount 
-			users { 
-				email 
-				name 
-				userId 
-			} 
+		userSearch(cursor: $userCursor) {
+			nextCursor
+			totalCount
+			users {
+				email
+				name
+				userId
+			}
 		}
 	 }`
+
+	usersQueryV2 = `organization {
+		userManagement {
+			authenticationDomains(id: $domainId) {
+			authenticationDomains {
+			  users(cursor: $userCursor) {
+				users {
+				  email
+				  id
+				  name
+				}
+				nextCursor
+				totalCount
+			  }
+			}
+		  }
+		}
+	  }`
 
 	accountsQuery = `accounts {
 		id
@@ -189,6 +207,7 @@ var (
 	AccountsQ    = fmt.Sprintf(actorBaseQ, accountsQuery)
 
 	UsersQ     = fmt.Sprintf(actorBaseQ, usersQuery)
+	UsersQV2   = fmt.Sprintf(actorBaseQ, usersQueryV2)
 	OrgDetailQ = fmt.Sprintf(actorBaseQ, orgDetailQuery)
 
 	RolesQ        = fmt.Sprintf(ManagementsQ, rolesQuery)
@@ -218,6 +237,13 @@ func composeUsersQuery() string {
 		`query ListUsers($userCursor: String) {
 			%s
 		}`, UsersQ)
+}
+
+func composeUsersQueryV2() string {
+	return fmt.Sprintf(
+		`query ListUsers($userCursor: String, $domainId: [ID!]) {
+			%s
+		}`, UsersQV2)
 }
 
 func composeOrgQuery() string {
@@ -349,6 +375,25 @@ type UsersResponse = QueryResponse[struct {
 			Users []User `json:"users"`
 		} `json:"userSearch"`
 	} `json:"users"`
+}]
+
+type UsersResponseV2 = QueryResponse[struct {
+	Organization struct {
+		UserManagement struct {
+			AuthenticationDomains struct {
+				AuthenticationDomains []struct {
+					Users struct {
+						ListBase
+						Users []struct {
+							Email string `json:"email"`
+							ID    string `json:"id"`
+							Name  string `json:"name"`
+						} `json:"users"`
+					} `json:"users"`
+				} `json:"authenticationDomains"`
+			} `json:"authenticationDomains"`
+		} `json:"userManagement"`
+	} `json:"organization"`
 }]
 
 type OrgResponse[T any] QueryResponse[struct {

--- a/pkg/newrelic/graphql.go
+++ b/pkg/newrelic/graphql.go
@@ -220,6 +220,7 @@ func composeAccountsQuery() string {
 		}`, AccountsQ)
 }
 
+// https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-manage-users/
 func composeUsersQuery() string {
 	return fmt.Sprintf(
 		`query ListUsers($userCursor: String, $domainId: [ID!]) {

--- a/pkg/newrelic/graphql.go
+++ b/pkg/newrelic/graphql.go
@@ -386,7 +386,7 @@ type UsersResponseV2 = QueryResponse[struct {
 				AuthenticationDomains []struct {
 					Users struct {
 						ListBase
-						Users []User `json:"users"`
+						Users []UserV2 `json:"users"`
 					} `json:"users"`
 				} `json:"authenticationDomains"`
 			} `json:"authenticationDomains"`

--- a/pkg/newrelic/graphql.go
+++ b/pkg/newrelic/graphql.go
@@ -6,7 +6,19 @@ import "fmt"
 const (
 	actorBaseQ = "actor { %s }"
 
-	usersQuery = `organization {
+	usersQuery = `users {
+		userSearch(cursor: $userCursor) {
+			nextCursor
+			totalCount
+			users {
+				email
+				name
+				userId
+			}
+		}
+	 }`
+
+	usersQueryV2 = `organization {
 		userManagement {
 			authenticationDomains(id: $domainId) {
 			authenticationDomains {
@@ -196,6 +208,7 @@ var (
 	AccountsQ    = fmt.Sprintf(actorBaseQ, accountsQuery)
 
 	UsersQ     = fmt.Sprintf(actorBaseQ, usersQuery)
+	UsersQV2   = fmt.Sprintf(actorBaseQ, usersQueryV2)
 	OrgDetailQ = fmt.Sprintf(actorBaseQ, orgDetailQuery)
 
 	RolesQ        = fmt.Sprintf(ManagementsQ, rolesQuery)
@@ -221,9 +234,16 @@ func composeAccountsQuery() string {
 }
 
 // https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-manage-users/
-func composeUsersQuery() string {
+func composeUsersQueryV2() string {
 	return fmt.Sprintf(
 		`query ListUsers($userCursor: String, $domainId: [ID!]) {
+			%s
+		}`, UsersQV2)
+}
+
+func composeUsersQuery() string {
+	return fmt.Sprintf(
+		`query ListUsers($userCursor: String) {
 			%s
 		}`, UsersQ)
 }

--- a/pkg/newrelic/graphql.go
+++ b/pkg/newrelic/graphql.go
@@ -6,19 +6,7 @@ import "fmt"
 const (
 	actorBaseQ = "actor { %s }"
 
-	usersQuery = `users {
-		userSearch(cursor: $userCursor) {
-			nextCursor
-			totalCount
-			users {
-				email
-				name
-				userId
-			}
-		}
-	 }`
-
-	usersQueryV2 = `organization {
+	usersQuery = `organization {
 		userManagement {
 			authenticationDomains(id: $domainId) {
 			authenticationDomains {
@@ -27,6 +15,7 @@ const (
 				  email
 				  id
 				  name
+				  emailVerificationState
 				}
 				nextCursor
 				totalCount
@@ -207,7 +196,6 @@ var (
 	AccountsQ    = fmt.Sprintf(actorBaseQ, accountsQuery)
 
 	UsersQ     = fmt.Sprintf(actorBaseQ, usersQuery)
-	UsersQV2   = fmt.Sprintf(actorBaseQ, usersQueryV2)
 	OrgDetailQ = fmt.Sprintf(actorBaseQ, orgDetailQuery)
 
 	RolesQ        = fmt.Sprintf(ManagementsQ, rolesQuery)
@@ -234,16 +222,9 @@ func composeAccountsQuery() string {
 
 func composeUsersQuery() string {
 	return fmt.Sprintf(
-		`query ListUsers($userCursor: String) {
-			%s
-		}`, UsersQ)
-}
-
-func composeUsersQueryV2() string {
-	return fmt.Sprintf(
 		`query ListUsers($userCursor: String, $domainId: [ID!]) {
 			%s
-		}`, UsersQV2)
+		}`, UsersQ)
 }
 
 func composeOrgQuery() string {
@@ -384,11 +365,7 @@ type UsersResponseV2 = QueryResponse[struct {
 				AuthenticationDomains []struct {
 					Users struct {
 						ListBase
-						Users []struct {
-							Email string `json:"email"`
-							ID    string `json:"id"`
-							Name  string `json:"name"`
-						} `json:"users"`
+						Users []User `json:"users"`
 					} `json:"users"`
 				} `json:"authenticationDomains"`
 			} `json:"authenticationDomains"`

--- a/pkg/newrelic/models.go
+++ b/pkg/newrelic/models.go
@@ -5,9 +5,10 @@ type BaseResource struct {
 }
 
 type User struct {
-	ID    string `json:"userId"`
-	Email string `json:"email"`
-	Name  string `json:"name"`
+	ID                     string `json:"id"`
+	Email                  string `json:"email"`
+	Name                   string `json:"name"`
+	EmailVerificationState string `json:"emailVerificationState"`
 }
 
 type Org struct {

--- a/pkg/newrelic/models.go
+++ b/pkg/newrelic/models.go
@@ -5,6 +5,12 @@ type BaseResource struct {
 }
 
 type User struct {
+	ID    string `json:"userId"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+type UserV2 struct {
 	ID                     string `json:"id"`
 	Email                  string `json:"email"`
 	Name                   string `json:"name"`


### PR DESCRIPTION
NewRelic API allows you to add unverified users(pending email verification) into groups causing `MISSING RESOURCE` when using the connector

Before changes ..
```
$ baton grants
1.708459839106087e+09	error	storecache/storecache.go:106	unable to find resource	{"resource_type_id": "user", "resource_id": "1005794016"}
1.708459839107775e+09	error	storecache/storecache.go:106	unable to find resource	{"resource_type_id": "user", "resource_id": "1005794069"}
1.7084598391082618e+09	error	storecache/storecache.go:106	unable to find resource	{"resource_type_id": "user", "resource_id": "1005795532"}
ID                                                                                 | Resource Type | Resource                      | Entitlement                                       | Principal
group:3e0720a8-f57b-4257-9b60-0ea8ee7871aa:member:user:1005794016                  | Group         | User                          | User Group member                                 | MISSING RESOURCE (user:1005794016)
group:3e0720a8-f57b-4257-9b60-0ea8ee7871aa:member:user:1005794069                  | Group         | User                          | User Group member                                 | MISSING RESOURCE (user:1005794069)
group:3e0720a8-f57b-4257-9b60-0ea8ee7871aa:member:user:1005795773                  | Group         | User                          | User Group member                                 | Mike Cool
group:1e9cde9c-db5d-4818-865e-e018ec0cbb75:member:user:1005793803                  | Group         | Admin                         | Admin Group member                                | Miguel Chavez
group:1e9cde9c-db5d-4818-865e-e018ec0cbb75:member:user:1005795532                  | Group         | Admin                         | Admin Group member                                | MISSING RESOURCE (user:1005795532)

```

<img width="908" alt="image" src="https://github.com/ConductorOne/baton-newrelic/assets/3094636/b0c1b852-07eb-498f-a9e0-78dd512e4b5a">
