### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-newrelic/main.go
+++ b/cmd/baton-newrelic/main.go
@@ -47,7 +47,7 @@ func getConnector(ctx context.Context, cc *cfg.Newrelic) (types.ConnectorServer,
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, cc.Apikey)
+	cb, err := connector.New(ctx, cc.Apikey, cc.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -5,6 +5,7 @@ import "reflect"
 
 type Newrelic struct {
 	Apikey string `mapstructure:"apikey"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Newrelic) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the NewRelic API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,11 @@ var (
 		field.WithDisplayName("API Key"),
 	)
 
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the NewRelic API URL (for testing)"),
+	)
+
 	// FieldRelationships defines relationships between the fields listed in
 	// Config that can be automatically validated.
 	FieldRelationships = []field.SchemaFieldRelationship{}
@@ -23,6 +28,7 @@ var (
 //go:generate go run ./gen
 var Config = field.NewConfiguration([]field.SchemaField{
 	Apikey,
+	BaseURLField,
 })
 
 // ValidateConfig is run after the configuration is loaded, and should return an

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the NewRelic API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -54,7 +54,7 @@ func (nr *NewRelic) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apikey string) (*NewRelic, error) {
+func New(ctx context.Context, apikey string, baseURL string) (*NewRelic, error) {
 	var httpClient *http.Client
 	var err error
 
@@ -65,7 +65,7 @@ func New(ctx context.Context, apikey string) (*NewRelic, error) {
 		}
 	}
 
-	nrClient, err := newrelic.NewClient(ctx, httpClient, apikey)
+	nrClient, err := newrelic.NewClient(ctx, httpClient, apikey, baseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/newrelic/client.go
+++ b/pkg/newrelic/client.go
@@ -12,6 +12,10 @@ import (
 const (
 	BaseHost        = "api.newrelic.com"
 	GraphQHEndpoint = "/graphql"
+
+	domainIDKey = "domainId"
+	roleIDKey   = "roleId"
+	groupIDKey  = "groupId"
 )
 
 type Client struct {
@@ -204,8 +208,8 @@ func (c *Client) ListRoles(ctx context.Context, cursor string) ([]Role, string, 
 func (c *Client) ListGroupsWithRole(ctx context.Context, domainId, roleId, cursor string) ([]Group, string, error) {
 	var res GroupsResponse
 	variables := map[string]interface{}{
-		"domainId": domainId,
-		"roleId":   roleId,
+		domainIDKey: domainId,
+		roleIDKey:   roleId,
 	}
 
 	// set variables for pagination
@@ -287,7 +291,7 @@ func (c *Client) ListDomains(ctx context.Context, cursor string) ([]Domain, stri
 func (c *Client) ListGroups(ctx context.Context, domainId, cursor string) ([]Group, string, error) {
 	var res GroupsResponse
 	variables := map[string]interface{}{
-		"domainId": domainId,
+		domainIDKey: domainId,
 	}
 
 	// set variables for pagination
@@ -323,8 +327,8 @@ func (c *Client) ListGroups(ctx context.Context, domainId, cursor string) ([]Gro
 func (c *Client) ListGroupMembers(ctx context.Context, domainId, groupId, cursor string) ([]string, string, error) {
 	var res GroupMembersResponse
 	variables := map[string]interface{}{
-		"domainId": domainId,
-		"groupId":  groupId,
+		domainIDKey: domainId,
+		groupIDKey:  groupId,
 	}
 
 	if cursor != "" {
@@ -375,7 +379,7 @@ func (c *Client) ListGroupMembers(ctx context.Context, domainId, groupId, cursor
 func (c *Client) AddUserToGroup(ctx context.Context, groupId, userId string) error {
 	var res AddGroupMemberResponse
 	variables := map[string]interface{}{
-		"groupId": groupId,
+		groupIDKey: groupId,
 		"userId":  userId,
 	}
 
@@ -395,7 +399,7 @@ func (c *Client) AddUserToGroup(ctx context.Context, groupId, userId string) err
 func (c *Client) RemoveUserFromGroup(ctx context.Context, groupId, userId string) error {
 	var res RemoveGroupMemberResponse
 	variables := map[string]interface{}{
-		"groupId": groupId,
+		groupIDKey: groupId,
 		"userId":  userId,
 	}
 
@@ -415,8 +419,8 @@ func (c *Client) RemoveUserFromGroup(ctx context.Context, groupId, userId string
 func (c *Client) AddGroupRole(ctx context.Context, roleId, groupId string) error {
 	var res GrantRoleResponse
 	variables := map[string]interface{}{
-		"groupId": groupId,
-		"roleId":  roleId,
+		groupIDKey: groupId,
+		roleIDKey:  roleId,
 	}
 
 	err := c.doRequest(
@@ -456,8 +460,8 @@ func (c *Client) AddAccountRole(ctx context.Context, roleId, groupId string, acc
 func (c *Client) AddOrgRole(ctx context.Context, roleId, groupId string) error {
 	var res GrantRoleResponse
 	variables := map[string]interface{}{
-		"roleId":  roleId,
-		"groupId": groupId,
+		roleIDKey:  roleId,
+		groupIDKey: groupId,
 	}
 
 	err := c.doRequest(
@@ -476,8 +480,8 @@ func (c *Client) AddOrgRole(ctx context.Context, roleId, groupId string) error {
 func (c *Client) RemoveGroupRole(ctx context.Context, roleId, groupId string) error {
 	var res RevokeRoleResponse
 	variables := map[string]interface{}{
-		"groupId": groupId,
-		"roleId":  roleId,
+		groupIDKey: groupId,
+		roleIDKey:  roleId,
 	}
 
 	err := c.doRequest(
@@ -517,8 +521,8 @@ func (c *Client) RemoveAccountRole(ctx context.Context, roleId, groupId string, 
 func (c *Client) RemoveOrgRole(ctx context.Context, roleId, groupId string) error {
 	var res RevokeRoleResponse
 	variables := map[string]interface{}{
-		"roleId":  roleId,
-		"groupId": groupId,
+		roleIDKey:  roleId,
+		groupIDKey: groupId,
 	}
 
 	err := c.doRequest(

--- a/pkg/newrelic/client.go
+++ b/pkg/newrelic/client.go
@@ -21,11 +21,20 @@ type Client struct {
 	baseURL    *url.URL
 }
 
-func NewClient(ctx context.Context, httpClient *http.Client, apikey string) (*Client, error) {
-	u := &url.URL{
-		Scheme: "https",
-		Host:   BaseHost,
-		Path:   GraphQHEndpoint,
+func NewClient(ctx context.Context, httpClient *http.Client, apikey string, baseURL string) (*Client, error) {
+	var u *url.URL
+	if baseURL != "" {
+		var err error
+		u, err = url.Parse(baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base URL: %w", err)
+		}
+	} else {
+		u = &url.URL{
+			Scheme: "https",
+			Host:   BaseHost,
+			Path:   GraphQHEndpoint,
+		}
 	}
 
 	var accId int


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-newrelic/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/newrelic/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-newrelic --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.