### PR TITLE
[CXH-1987] - Containerize connector: SDK V2 + session storage

### DIFF
--- a/cmd/baton-newrelic/main.go
+++ b/cmd/baton-newrelic/main.go
@@ -25,7 +25,7 @@ func main() {
 		"baton-newrelic",
 		getConnector,
 		cfg.Config,
-		connectorrunner.WithDefaultCapabilitiesConnectorBuilder(&connector.NewRelic{}),
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.NewRelic{}),
 	)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/cmd/baton-newrelic/main.go
+++ b/cmd/baton-newrelic/main.go
@@ -2,15 +2,13 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	cfg "github.com/conductorone/baton-newrelic/pkg/config"
 	"github.com/conductorone/baton-newrelic/pkg/connector"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/config"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
-	"github.com/conductorone/baton-sdk/pkg/types"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
@@ -20,44 +18,27 @@ var version = "dev"
 func main() {
 	ctx := context.Background()
 
-	_, cmd, err := config.DefineConfiguration(
+	config.RunConnector(
 		ctx,
 		"baton-newrelic",
-		getConnector,
+		version,
 		cfg.Config,
+		getConnector,
 		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.NewRelic{}),
 	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cmd.Version = version
-
-	err = cmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
 }
 
-func getConnector(ctx context.Context, cc *cfg.Newrelic) (types.ConnectorServer, error) {
+func getConnector(ctx context.Context, cc *cfg.Newrelic, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
 	l := ctxzap.Extract(ctx)
 	if err := cfg.ValidateConfig(cc); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	cb, err := connector.New(ctx, cc.Apikey, cc.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
-		return nil, err
+		return nil, nil, err
 	}
 
-	c, err := connectorbuilder.NewConnector(ctx, cb)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-
-	return c, nil
+	return cb, nil, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,10 +28,15 @@ var (
 )
 
 //go:generate go run ./gen
-var Config = field.NewConfiguration([]field.SchemaField{
-	Apikey,
-	BaseURLField,
-})
+var Config = field.NewConfiguration(
+	[]field.SchemaField{
+		Apikey,
+		BaseURLField,
+	},
+	field.WithConnectorDisplayName("New Relic"),
+	field.WithIconUrl("/static/app-icons/new-relic.svg"),
+	field.WithHelpUrl("/docs/baton/new-relic"),
+)
 
 // ValidateConfig is run after the configuration is loaded, and should return an
 // error if it isn't valid. Implementing this function is optional, it only

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,9 +18,9 @@ type NewRelic struct {
 	client *newrelic.Client
 }
 
-// ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
-func (nr *NewRelic) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	return []connectorbuilder.ResourceSyncer{
+// ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
+func (nr *NewRelic) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	return []connectorbuilder.ResourceSyncerV2{
 		newOrgBuilder(nr.client),
 		newUserBuilder(nr.client),
 		newGroupBuilder(nr.client),

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
+
 const (
 	groupMembership = "member"
 )
@@ -53,29 +54,25 @@ func groupResource(ctx context.Context, parentId *v2.ResourceId, domainId string
 
 // List returns all the groups from the database as resource objects.
 // Groups include a GroupTrait because they are the 'shape' of a standard group.
-func (g *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (g *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentResourceID == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
-	// parse the token
-	bag, err := parsePageToken(pToken.Token, &v2.ResourceId{ResourceType: domainResourceType})
+	bag, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: domainResourceType})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	switch bag.ResourceTypeID() {
 	case domainResourceType:
-		// list and paginate through domains
 		domains, nextDomainsCursor, err := g.client.ListDomains(ctx, bag.PageToken())
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
-		// remove old cursors from bag
 		bag.Pop()
 
-		// add cursor for paginating next domains to bag
 		if nextDomainsCursor != "" {
 			bag.Push(
 				pagination.PageState{
@@ -90,7 +87,6 @@ func (g *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 				continue
 			}
 
-			// add cursors for paginating groups under this domain
 			bag.Push(
 				pagination.PageState{
 					ResourceTypeID: groupResourceType.Id,
@@ -99,46 +95,42 @@ func (g *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 			)
 		}
 
-		// if there are no more cursors, return nil
 		var token string
 		if bag.Current() != nil {
 			token = bag.PageToken()
 		}
 
-		// handle next iteration
 		next, err := bag.NextToken(token)
 		if err != nil {
 			if err.Error() != "no active page state" {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 		}
 
-		return nil, next, nil, nil
+		return nil, &rs.SyncOpResults{NextPageToken: next}, nil
 
 	case groupResourceType.Id:
-		// list and paginate through groups within a domain
 		parts := strings.Split(bag.PageToken(), ":")
 		if len(parts) != 2 {
-			return nil, "", nil, fmt.Errorf("invalid page token: %s (type: %s)", bag.PageToken(), bag.ResourceTypeID())
+			return nil, nil, fmt.Errorf("invalid page token: %s (type: %s)", bag.PageToken(), bag.ResourceTypeID())
 		}
 
 		domainId := parts[0]
 		cursor := parts[1]
 
-		// list all groups within all domains with specific role
 		groups, nextGroupsCursor, err := g.client.ListGroups(ctx, domainId, cursor)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		c, err := composeCursor(domainId, nextGroupsCursor)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		next, err := bag.NextToken(c)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		var rv []*v2.Resource
@@ -147,21 +139,21 @@ func (g *groupBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 
 			gr, err := groupResource(ctx, parentResourceID, domainId, &groupCopy)
 			if err != nil {
-				return nil, "", nil, err
+				return nil, nil, err
 			}
 
 			rv = append(rv, gr)
 		}
 
-		return rv, next, nil, nil
+		return rv, &rs.SyncOpResults{NextPageToken: next}, nil
 
 	default:
-		return nil, "", nil, fmt.Errorf("invalid resource type: %s", bag.ResourceTypeID())
+		return nil, nil, fmt.Errorf("invalid resource type: %s", bag.ResourceTypeID())
 	}
 }
 
-// Entitlements always returns an empty slice for groups.
-func (g *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+// Entitlements returns the member entitlement for a group.
+func (g *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
 	permissionOptions := []ent.EntitlementOption{
@@ -172,35 +164,34 @@ func (g *groupBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ 
 
 	rv = append(rv, ent.NewAssignmentEntitlement(resource, groupMembership, permissionOptions...))
 
-	return rv, "", nil, nil
+	return rv, &rs.SyncOpResults{}, nil
 }
 
-// Grants always returns an empty slice for groups since they don't have any entitlements.
-func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	bag, err := parsePageToken(pToken.Token, &v2.ResourceId{ResourceType: userResourceType.Id})
+// Grants returns grants for members of a group.
+func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	bag, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: userResourceType.Id})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	// obtain domain id from group profile
 	groupTrait, err := rs.GetGroupTrait(resource)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	domainId, ok := rs.GetProfileStringValue(groupTrait.Profile, "group_domain")
 	if !ok {
-		return nil, "", nil, fmt.Errorf("unable to get domain id from group trait profile")
+		return nil, nil, fmt.Errorf("unable to get domain id from group trait profile")
 	}
 
 	members, nextDomainsCursor, err := g.client.ListGroupMembers(ctx, domainId, resource.Id.Resource, bag.PageToken())
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	next, err := bag.NextToken(nextDomainsCursor)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var rv []*v2.Grant
@@ -215,7 +206,7 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 		))
 	}
 
-	return rv, next, nil, nil
+	return rv, &rs.SyncOpResults{NextPageToken: next}, nil
 }
 
 func (g *groupBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -16,7 +16,6 @@ import (
 	"go.uber.org/zap"
 )
 
-
 const (
 	groupMembership = "member"
 )

--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/conductorone/baton-newrelic/pkg/newrelic"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
@@ -39,33 +37,32 @@ func orgResource(ctx context.Context, org *newrelic.Org) (*v2.Resource, error) {
 }
 
 // List returns all the orgs from the database as resource objects.
-// Orgs include a OrgTrait because they are the 'shape' of a standard org.
-func (o *orgBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (o *orgBuilder) List(ctx context.Context, _ *v2.ResourceId, _ rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	org, err := o.client.GetOrg(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var rv []*v2.Resource
 
 	or, err := orgResource(ctx, org)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	rv = append(rv, or)
 
-	return rv, "", nil, nil
+	return rv, &rs.SyncOpResults{}, nil
 }
 
 // Entitlements always returns an empty slice for orgs.
-func (o *orgBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (o *orgBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // Grants always returns an empty slice for orgs since they don't have any entitlements.
-func (o *orgBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (o *orgBuilder) Grants(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newOrgBuilder(client *newrelic.Client) *orgBuilder {

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -54,26 +54,24 @@ func roleResource(ctx context.Context, pId *v2.ResourceId, role *newrelic.Role) 
 
 // List returns all the roles from the database as resource objects.
 // Roles include a RoleTrait because they are the 'shape' of a standard role.
-func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	if parentResourceID == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
-	// parse the token
-	bag, err := parsePageToken(pToken.Token, &v2.ResourceId{ResourceType: roleResourceType.Id})
+	bag, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: roleResourceType.Id})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	roles, nextCursor, err := r.client.ListRoles(ctx, bag.PageToken())
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	// add next cursor to bag
 	next, err := bag.NextToken(nextCursor)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var rv []*v2.Resource
@@ -81,34 +79,32 @@ func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		roleCopy := role
 		rr, err := roleResource(ctx, parentResourceID, &roleCopy)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		rv = append(rv, rr)
 	}
 
-	return rv, next, nil, nil
+	return rv, &rs.SyncOpResults{NextPageToken: next}, nil
 }
 
-// Entitlements always returns an empty slice for roles.
-func (r *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+// Entitlements returns the member entitlement for a role.
+func (r *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
 	rolesTrait, err := rs.GetRoleTrait(resource)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	// get role scope
 	roleScope, ok := rs.GetProfileStringValue(rolesTrait.Profile, "role_scope")
 	if !ok {
-		return nil, "", nil, fmt.Errorf("unable to get role scope from role trait profile")
+		return nil, nil, fmt.Errorf("unable to get role scope from role trait profile")
 	}
 
-	// get role name
 	roleName, ok := rs.GetProfileStringValue(rolesTrait.Profile, "role_name")
 	if !ok {
-		return nil, "", nil, fmt.Errorf("unable to get role name from role trait profile")
+		return nil, nil, fmt.Errorf("unable to get role name from role trait profile")
 	}
 
 	permissionOptions := []ent.EntitlementOption{
@@ -119,29 +115,25 @@ func (r *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *
 
 	rv = append(rv, ent.NewAssignmentEntitlement(resource, roleName, permissionOptions...))
 
-	return rv, "", nil, nil
+	return rv, &rs.SyncOpResults{}, nil
 }
 
-// Grants always returns an empty slice for roles since they don't have any entitlements.
-func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	// parse the token
-	bag, err := parsePageToken(pToken.Token, &v2.ResourceId{ResourceType: domainResourceType})
+// Grants returns grants for groups assigned to a role.
+func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	bag, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: domainResourceType})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	switch bag.ResourceTypeID() {
 	case domainResourceType:
-		// list and paginate through all domains
 		domains, nextDomainsCursor, err := r.client.ListDomains(ctx, bag.PageToken())
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
-		// remove old cursors from bag
 		bag.Pop()
 
-		// push next cursor for paginating domains
 		if nextDomainsCursor != "" {
 			bag.Push(
 				pagination.PageState{
@@ -156,7 +148,6 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 				continue
 			}
 
-			// push cursor for paginating groups under domain
 			bag.Push(
 				pagination.PageState{
 					ResourceTypeID: groupResourceType.Id,
@@ -167,52 +158,47 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 
 		next, err := bag.NextToken(bag.PageToken())
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
-		return nil, next, nil, nil
+		return nil, &rs.SyncOpResults{NextPageToken: next}, nil
 
 	case groupResourceType.Id:
-		// list and paginate through groups under specific domain
 		parts := strings.Split(bag.PageToken(), ":")
 		if len(parts) != 2 {
-			return nil, "", nil, fmt.Errorf("invalid page token: %s (type: %s)", bag.PageToken(), bag.ResourceTypeID())
+			return nil, nil, fmt.Errorf("invalid page token: %s (type: %s)", bag.PageToken(), bag.ResourceTypeID())
 		}
 
 		domainId := parts[0]
 		cursor := parts[1]
 
-		// get role trait
 		rolesTrait, err := rs.GetRoleTrait(resource)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
-		// get role name for entitlement id
 		roleName, ok := rs.GetProfileStringValue(rolesTrait.Profile, "role_name")
 		if !ok {
-			return nil, "", nil, fmt.Errorf("unable to get role name from role trait profile")
+			return nil, nil, fmt.Errorf("unable to get role name from role trait profile")
 		}
 
-		// list all groups within all domains with specific role
 		groups, nextGroupsCursor, err := r.client.ListGroupsWithRole(ctx, domainId, resource.Id.Resource, cursor)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		c, err := composeCursor(domainId, nextGroupsCursor)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		next, err := bag.NextToken(c)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		var rv []*v2.Grant
 		for _, g := range groups {
-			// skip groups without roles
 			if g.Roles.TotalCount == 0 {
 				continue
 			}
@@ -232,10 +218,10 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken 
 			))
 		}
 
-		return rv, next, nil, nil
+		return rv, &rs.SyncOpResults{NextPageToken: next}, nil
 
 	default:
-		return nil, "", nil, fmt.Errorf("invalid resource type: %s", bag.ResourceTypeID())
+		return nil, nil, fmt.Errorf("invalid resource type: %s", bag.ResourceTypeID())
 	}
 }
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/conductorone/baton-newrelic/pkg/newrelic"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
@@ -50,24 +48,23 @@ func userResource(ctx context.Context, pId *v2.ResourceId, user *newrelic.User) 
 
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
-func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts resource.SyncOpAttrs) ([]*v2.Resource, *resource.SyncOpResults, error) {
 	var (
 		nextCursor, domainID string
 		users                []newrelic.User
 	)
 	if parentResourceID == nil {
-		return nil, "", nil, nil
+		return nil, nil, nil
 	}
 
-	// parse the token
-	bag, err := parsePageToken(pToken.Token, &v2.ResourceId{ResourceType: userResourceType.Id})
+	bag, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: userResourceType.Id})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	domains, _, err := u.client.ListDomains(ctx, bag.PageToken())
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	if len(domains) == 1 {
@@ -82,13 +79,12 @@ func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 
 	users, nextCursor, err = u.client.ListUsers(ctx, domainID, bag.PageToken())
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
-	// add next cursor to bag
 	next, err := bag.NextToken(nextCursor)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	var rv []*v2.Resource
@@ -96,23 +92,23 @@ func (u *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		userCopy := user
 		ur, err := userResource(ctx, parentResourceID, &userCopy)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 
 		rv = append(rv, ur)
 	}
 
-	return rv, next, nil, nil
+	return rv, &resource.SyncOpResults{NextPageToken: next}, nil
 }
 
 // Entitlements always returns an empty slice for users.
-func (u *userBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (u *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Entitlement, *resource.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
-func (u *userBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (u *userBuilder) Grants(_ context.Context, _ *v2.Resource, _ resource.SyncOpAttrs) ([]*v2.Grant, *resource.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newUserBuilder(client *newrelic.Client) *userBuilder {


### PR DESCRIPTION
## Summary

Fixes CXH-1987

This PR implements the connector-repo phase of the CXH-1987 containerize-connector flow.

**AC item investigation results:**

- **Update baton-sdk to latest version** — Already satisfied. The SDK is at `v0.17.0`, which is the current latest tag (`gh api repos/conductorone/baton-sdk/releases/latest` returned `v0.17.0`). No bump needed.

- **Refactor connector to implement ResourceSyncerV2** — Applied. All four resource syncer builders (`orgBuilder`, `userBuilder`, `groupBuilder`, `roleBuilder`) now implement `connectorbuilder.ResourceSyncerV2` instead of `ResourceSyncer`. The connector struct now implements `ConnectorBuilderV2` (returning `[]ResourceSyncerV2` from `ResourceSyncers`), and `main.go` uses `connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2`. Method signatures updated: `List`/`Entitlements`/`Grants` now accept `resource.SyncOpAttrs` (contains `PageToken`, `Session`, `SyncID`) instead of `*pagination.Token`, and return `*resource.SyncOpResults` instead of `(string, annotations.Annotations)`. `Grant`/`Revoke` provisioner methods are unchanged — they implement `ResourceProvisioner` which the SDK detects separately.

- **Replace mutex cache by session storage implementation** — Not applicable to this connector. A full search of all Go files outside `vendor/` found zero uses of `sync.Mutex`, `sync.RWMutex`, or any mutex-based cache pattern. The `SyncOpAttrs.Session` field (SDK session store) is available via the `opts` parameter passed to each V2 method but there is nothing to migrate in this codebase.

**Compile gate:** `go build ./...`, `go vet ./...`, `go test ./...` — all clean (no test files in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)