### PR TITLE
[CXH-1493] - fix: migrate deprecated trait-level profile/status APIs

### DIFF
--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -37,10 +37,9 @@ func groupResource(ctx context.Context, parentId *v2.ResourceId, domainId string
 		group.Name,
 		groupResourceType,
 		group.ID,
-		[]rs.GroupTraitOption{
-			rs.WithGroupProfile(profile),
-		},
+		nil,
 		rs.WithParentResourceID(parentId),
+		rs.WithResourceProfile(profile),
 	)
 
 	if err != nil {
@@ -174,12 +173,7 @@ func (g *groupBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 		return nil, nil, err
 	}
 
-	groupTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	domainId, ok := rs.GetProfileStringValue(groupTrait.Profile, "group_domain")
+	domainId, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "group_domain")
 	if !ok {
 		return nil, nil, fmt.Errorf("unable to get domain id from group trait profile")
 	}

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -38,10 +38,9 @@ func roleResource(ctx context.Context, pId *v2.ResourceId, role *newrelic.Role) 
 		role.DisplayName,
 		roleResourceType,
 		role.ID,
-		[]rs.RoleTraitOption{
-			rs.WithRoleProfile(profile),
-		},
+		nil,
 		rs.WithParentResourceID(pId),
+		rs.WithResourceProfile(profile),
 	)
 
 	if err != nil {
@@ -91,17 +90,12 @@ func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 func (r *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
-	rolesTrait, err := rs.GetRoleTrait(resource)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	roleScope, ok := rs.GetProfileStringValue(rolesTrait.Profile, "role_scope")
+	roleScope, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "role_scope")
 	if !ok {
 		return nil, nil, fmt.Errorf("unable to get role scope from role trait profile")
 	}
 
-	roleName, ok := rs.GetProfileStringValue(rolesTrait.Profile, "role_name")
+	roleName, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "role_name")
 	if !ok {
 		return nil, nil, fmt.Errorf("unable to get role name from role trait profile")
 	}
@@ -180,12 +174,7 @@ func (r *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs
 		domainId := parts[0]
 		cursor := parts[1]
 
-		rolesTrait, err := rs.GetRoleTrait(resource)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		roleName, ok := rs.GetProfileStringValue(rolesTrait.Profile, "role_name")
+		roleName, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "role_name")
 		if !ok {
 			return nil, nil, fmt.Errorf("unable to get role name from role trait profile")
 		}
@@ -244,18 +233,13 @@ func (r *roleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitle
 		return nil, fmt.Errorf("baton-newrelic: only groups can be granted role membership")
 	}
 
-	// check if principal is valid in regards to scope of role entitlement
-	roleTrait, err := rs.GetRoleTrait(entitlement.Resource)
-	if err != nil {
-		return nil, err
-	}
-
-	roleScope, ok := rs.GetProfileStringValue(roleTrait.Profile, "role_scope")
+	roleScope, ok := rs.GetProfileStringValue(rs.GetProfile(entitlement.Resource), "role_scope")
 	if !ok {
 		return nil, fmt.Errorf("unable to get role scope from role trait profile")
 	}
 
 	roleId, groupId := entitlement.Resource.Id.Resource, principal.Id.Resource
+	var err error
 	switch roleScope {
 	case orgScope:
 		err = r.client.AddOrgRole(ctx, roleId, groupId)
@@ -285,18 +269,13 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 		return nil, fmt.Errorf("baton-newrelic: only groups can have role membership revoked")
 	}
 
-	// check if principal is valid in regards to scope of role entitlement
-	roleTrait, err := rs.GetRoleTrait(entitlement.Resource)
-	if err != nil {
-		return nil, err
-	}
-
-	roleScope, ok := rs.GetProfileStringValue(roleTrait.Profile, "role_scope")
+	roleScope, ok := rs.GetProfileStringValue(rs.GetProfile(entitlement.Resource), "role_scope")
 	if !ok {
 		return nil, fmt.Errorf("unable to get role scope from role trait profile")
 	}
 
 	roleId, groupId := entitlement.Resource.Id.Resource, principal.Id.Resource
+	var err error
 	switch roleScope {
 	case orgScope:
 		err = r.client.RemoveOrgRole(ctx, roleId, groupId)

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -46,19 +46,6 @@ func (u *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 	return userResourceType
 }
 
-func userTraitStatusToResourceStatus(status v2.UserTrait_Status_Status) v2.Status_ResourceStatus {
-	switch status {
-	case v2.UserTrait_Status_STATUS_ENABLED:
-		return v2.Status_RESOURCE_STATUS_ENABLED
-	case v2.UserTrait_Status_STATUS_DISABLED:
-		return v2.Status_RESOURCE_STATUS_DISABLED
-	case v2.UserTrait_Status_STATUS_DELETED:
-		return v2.Status_RESOURCE_STATUS_DELETED
-	default:
-		return v2.Status_RESOURCE_STATUS_UNSPECIFIED
-	}
-}
-
 func userResource(ctx context.Context, pId *v2.ResourceId, user *newrelic.User) (*v2.Resource, error) {
 	firstName, lastName := resource.SplitFullName(user.Name)
 	profile := map[string]interface{}{
@@ -70,9 +57,9 @@ func userResource(ctx context.Context, pId *v2.ResourceId, user *newrelic.User) 
 
 	// A user whose invite hasn't been accepted yet (emailVerificationState ==
 	// "Pending") can't do anything with the account, so it's not yet enabled.
-	status := v2.UserTrait_Status_STATUS_ENABLED
+	status := v2.Status_RESOURCE_STATUS_ENABLED
 	if user.EmailVerificationState == emailVerificationStatePending {
-		status = v2.UserTrait_Status_STATUS_DISABLED
+		status = v2.Status_RESOURCE_STATUS_DISABLED
 	}
 
 	resource, err := resource.NewUserResource(
@@ -85,7 +72,7 @@ func userResource(ctx context.Context, pId *v2.ResourceId, user *newrelic.User) 
 		},
 		resource.WithParentResourceID(pId),
 		resource.WithResourceProfile(profile),
-		resource.WithResourceStatus(userTraitStatusToResourceStatus(status), ""),
+		resource.WithResourceStatus(status, ""),
 	)
 
 	if err != nil {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -46,6 +46,19 @@ func (u *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 	return userResourceType
 }
 
+func userTraitStatusToResourceStatus(status v2.UserTrait_Status_Status) v2.Status_ResourceStatus {
+	switch status {
+	case v2.UserTrait_Status_STATUS_ENABLED:
+		return v2.Status_RESOURCE_STATUS_ENABLED
+	case v2.UserTrait_Status_STATUS_DISABLED:
+		return v2.Status_RESOURCE_STATUS_DISABLED
+	case v2.UserTrait_Status_STATUS_DELETED:
+		return v2.Status_RESOURCE_STATUS_DELETED
+	default:
+		return v2.Status_RESOURCE_STATUS_UNSPECIFIED
+	}
+}
+
 func userResource(ctx context.Context, pId *v2.ResourceId, user *newrelic.User) (*v2.Resource, error) {
 	firstName, lastName := resource.SplitFullName(user.Name)
 	profile := map[string]interface{}{
@@ -67,12 +80,12 @@ func userResource(ctx context.Context, pId *v2.ResourceId, user *newrelic.User) 
 		userResourceType,
 		user.ID,
 		[]resource.UserTraitOption{
-			resource.WithUserProfile(profile),
 			resource.WithEmail(user.Email, true),
 			resource.WithUserLogin(user.Email),
-			resource.WithStatus(status),
 		},
 		resource.WithParentResourceID(pId),
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(userTraitStatusToResourceStatus(status), ""),
 	)
 
 	if err != nil {

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -33,12 +33,13 @@ func TestUserResource_PendingEmailVerificationIsDisabled(t *testing.T) {
 		t.Fatalf("userResource: %v", err)
 	}
 
-	trait, err := rs.GetUserTrait(r)
-	if err != nil {
-		t.Fatalf("GetUserTrait: %v", err)
-	}
-	if trait.GetStatus().GetStatus() != v2.UserTrait_Status_STATUS_DISABLED {
-		t.Errorf("status = %v, want STATUS_DISABLED for Pending user", trait.GetStatus().GetStatus())
+	status := rs.GetStatus(r)
+	if status == nil || status.GetStatus() != v2.Status_RESOURCE_STATUS_DISABLED {
+		got := v2.Status_RESOURCE_STATUS_UNSPECIFIED
+		if status != nil {
+			got = status.GetStatus()
+		}
+		t.Errorf("status = %v, want RESOURCE_STATUS_DISABLED for Pending user", got)
 	}
 }
 
@@ -55,12 +56,13 @@ func TestUserResource_VerifiedEmailIsEnabled(t *testing.T) {
 		t.Fatalf("userResource: %v", err)
 	}
 
-	trait, err := rs.GetUserTrait(r)
-	if err != nil {
-		t.Fatalf("GetUserTrait: %v", err)
-	}
-	if trait.GetStatus().GetStatus() != v2.UserTrait_Status_STATUS_ENABLED {
-		t.Errorf("status = %v, want STATUS_ENABLED for Verified user", trait.GetStatus().GetStatus())
+	status := rs.GetStatus(r)
+	if status == nil || status.GetStatus() != v2.Status_RESOURCE_STATUS_ENABLED {
+		got := v2.Status_RESOURCE_STATUS_UNSPECIFIED
+		if status != nil {
+			got = status.GetStatus()
+		}
+		t.Errorf("status = %v, want RESOURCE_STATUS_ENABLED for Verified user", got)
 	}
 }
 
@@ -77,12 +79,13 @@ func TestUserResource_NotVerifiableEmailIsEnabled(t *testing.T) {
 		t.Fatalf("userResource: %v", err)
 	}
 
-	trait, err := rs.GetUserTrait(r)
-	if err != nil {
-		t.Fatalf("GetUserTrait: %v", err)
-	}
-	if trait.GetStatus().GetStatus() != v2.UserTrait_Status_STATUS_ENABLED {
-		t.Errorf("status = %v, want STATUS_ENABLED for Not Verifiable user", trait.GetStatus().GetStatus())
+	status := rs.GetStatus(r)
+	if status == nil || status.GetStatus() != v2.Status_RESOURCE_STATUS_ENABLED {
+		got := v2.Status_RESOURCE_STATUS_UNSPECIFIED
+		if status != nil {
+			got = status.GetStatus()
+		}
+		t.Errorf("status = %v, want RESOURCE_STATUS_ENABLED for Not Verifiable user", got)
 	}
 }
 


### PR DESCRIPTION
Fixes CXH-1493

`main`'s `verify / lint` check went red after PR #14 merged (16 staticcheck SA1019 hits) because the connector still used deprecated baton-sdk trait-level resource-option APIs. This migrates to the resource-level equivalents:

- `WithUserProfile` / `WithGroupProfile` / `WithRoleProfile` → `WithResourceProfile`
- `WithStatus` → `WithResourceStatus`
- Trait-level profile reads (`GetGroupTrait(...).Profile`, `GetRoleTrait(...).Profile`) → `rs.GetProfile(resource)`
- Test assertions on `trait.GetStatus()` → `rs.GetStatus(resource)`

No behavior change — same migration already applied on baton-lucidchart and baton-rapid7 after the same SDK bump.

Verified locally: `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)